### PR TITLE
01 add config to toggle override entity

### DIFF
--- a/src/Controller/BaseImportControllerTrait.php
+++ b/src/Controller/BaseImportControllerTrait.php
@@ -83,6 +83,7 @@ trait BaseImportControllerTrait
                 'header_info' => $matrix->getHeaderInfo($this->getImportConfiguration($entityManager)->getEntityClassName()),
                 'data' => $matrix->getRecords(),
                 'form' => $this->createMatrixForm($matrix, $entityManager)->createView(),
+                'importConfiguration' => $this->getImportConfiguration($entityManager),
             ]
         );
     }

--- a/src/Controller/BaseImportControllerTrait.php
+++ b/src/Controller/BaseImportControllerTrait.php
@@ -113,6 +113,8 @@ trait BaseImportControllerTrait
 
             $msg = $translator->trans('success.import', [], 'BatchEntityImportBundle');
             $this->addFlash('success', $msg);
+
+            return $this->redirectToImport();
         }
 
         return $this->prepareView(

--- a/src/Controller/BaseImportControllerTrait.php
+++ b/src/Controller/BaseImportControllerTrait.php
@@ -7,7 +7,6 @@ namespace JG\BatchEntityImportBundle\Controller;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use JG\BatchEntityImportBundle\Form\Type\FileImportType;
-use JG\BatchEntityImportBundle\Form\Type\MatrixType;
 use JG\BatchEntityImportBundle\Model\Configuration\ImportConfigurationInterface;
 use JG\BatchEntityImportBundle\Model\FileImport;
 use JG\BatchEntityImportBundle\Model\Matrix\Matrix;
@@ -80,7 +79,7 @@ trait BaseImportControllerTrait
     protected function prepareMatrixEditView(Matrix $matrix, EntityManagerInterface $entityManager): Response
     {
         $form = $this->createMatrixForm($matrix, $entityManager);
-        $form->submit(['records' => array_map(fn(MatrixRecord $record) => $record->getData(), $matrix->getRecords())]);
+        $form->submit(['records' => array_map(static fn (MatrixRecord $record) => $record->getData(), $matrix->getRecords())]);
 
         return $this->prepareView(
             $this->getMatrixEditTemplateName(),

--- a/src/Form/Type/MatrixRecordType.php
+++ b/src/Form/Type/MatrixRecordType.php
@@ -29,7 +29,7 @@ class MatrixRecordType extends AbstractType
         $configuration = $options['configuration'];
         $fieldDefinitions = $configuration->getFieldsDefinitions();
 
-        if($configuration->allowOverrideEntity()){
+        if ($configuration->allowOverrideEntity()) {
             $this->addEntityField($builder, $configuration->getEntityClassName());
         }
 

--- a/src/Form/Type/MatrixRecordType.php
+++ b/src/Form/Type/MatrixRecordType.php
@@ -29,7 +29,9 @@ class MatrixRecordType extends AbstractType
         $configuration = $options['configuration'];
         $fieldDefinitions = $configuration->getFieldsDefinitions();
 
-        $this->addEntityField($builder, $configuration->getEntityClassName());
+        if($configuration->allowOverrideEntity()){
+            $this->addEntityField($builder, $configuration->getEntityClassName());
+        }
 
         $builder->addEventListener(
             FormEvents::PRE_SET_DATA,

--- a/src/Model/Configuration/AbstractImportConfiguration.php
+++ b/src/Model/Configuration/AbstractImportConfiguration.php
@@ -80,4 +80,9 @@ abstract class AbstractImportConfiguration implements ImportConfigurationInterfa
 
         return new $class();
     }
+
+    public function allowOverrideEntity(): bool
+    {
+        return true;
+    }
 }

--- a/src/Model/Configuration/ImportConfigurationInterface.php
+++ b/src/Model/Configuration/ImportConfigurationInterface.php
@@ -15,6 +15,11 @@ interface ImportConfigurationInterface
     public function getEntityClassName(): string;
 
     /**
+     * Allow to override entity in the edit view
+     */
+    public function allowOverrideEntity(): bool;
+
+    /**
      * Defines fields definitions used during process of data editing.
      * If definition for field will not be defined, default definition will be used.
      *

--- a/src/Model/Configuration/ImportConfigurationInterface.php
+++ b/src/Model/Configuration/ImportConfigurationInterface.php
@@ -15,7 +15,7 @@ interface ImportConfigurationInterface
     public function getEntityClassName(): string;
 
     /**
-     * Allow to override entity in the edit view
+     * Allow to override entity in the edit view.
      */
     public function allowOverrideEntity(): bool;
 

--- a/src/Model/Matrix/Matrix.php
+++ b/src/Model/Matrix/Matrix.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace JG\BatchEntityImportBundle\Model\Matrix;
 
 use const ARRAY_FILTER_USE_KEY;
+use JG\BatchEntityImportBundle\Utils\ColumnNameHelper;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class Matrix
@@ -57,6 +59,16 @@ class Matrix
     {
         $info = [];
         foreach ($this->header as $name) {
+            $locale = ColumnNameHelper::getLocale($name);
+            if (is_subclass_of($className, TranslatableInterface::class) && $locale) {
+                $nameWithoutTransSuffix = ColumnNameHelper::removeTranslationSuffix($name);
+                $fieldName = ColumnNameHelper::underscoreToPascalCase($nameWithoutTransSuffix);
+
+                $info[$name] = method_exists($className, sprintf('get%s', $fieldName));
+
+                continue;
+            }
+
             $info[$name] = property_exists($className, $name);
         }
 

--- a/src/Model/Matrix/Matrix.php
+++ b/src/Model/Matrix/Matrix.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace JG\BatchEntityImportBundle\Model\Matrix;
 
 use const ARRAY_FILTER_USE_KEY;
-use JG\BatchEntityImportBundle\Service\PropertyExistenceChecker;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class Matrix

--- a/src/Model/Matrix/Matrix.php
+++ b/src/Model/Matrix/Matrix.php
@@ -57,10 +57,8 @@ class Matrix
     public function getHeaderInfo(string $className): array
     {
         $info = [];
-        $checker = new PropertyExistenceChecker(new $className());
-
         foreach ($this->header as $name) {
-            $info[$name] = $checker->propertyExists($name);
+            $info[$name] = property_exists($className, $name);
         }
 
         return $info;

--- a/src/Resources/views/edit_matrix.html.twig
+++ b/src/Resources/views/edit_matrix.html.twig
@@ -5,7 +5,7 @@
         {{ form_start(form) }}
         <table class="table">
             <tr>
-                <th>{{ 'matrix.header.label.override'|trans({}, 'BatchEntityImportBundle') }}</th>
+                {% if importConfiguration.allowOverrideEntity %}<th>{{ 'matrix.header.label.override'|trans({}, 'BatchEntityImportBundle') }}</th>{% endif %}
                 {% for name, exists in header_info %}
                     <th>
                         {% if not exists %}

--- a/src/Resources/views/edit_matrix.html.twig
+++ b/src/Resources/views/edit_matrix.html.twig
@@ -1,13 +1,15 @@
 {% extends batch_entity_import_template('layout') %}
 
 {% block batch_entity_import_content %}
+    {% form_theme form 'bootstrap_3_layout.html.twig' %}
+
     <div class="table-responsive">
         {{ form_start(form) }}
         <table class="table">
             <tr>
                 {% if importConfiguration.allowOverrideEntity %}<th>{{ 'matrix.header.label.override'|trans({}, 'BatchEntityImportBundle') }}</th>{% endif %}
                 {% for name, exists in header_info %}
-                    <th>
+                    <th style="min-width: 150px;">
                         {% if not exists %}
                             <div>{{ 'matrix.header.label.unknown'|trans({}, 'BatchEntityImportBundle') }}</div>
                         {% endif %}
@@ -21,8 +23,10 @@
                 <tr>
                     {% for elem in record.children %}
                         <td>
-                            {{ form_errors(elem) }}
-                            {{ form_widget(elem) }}
+                            <div class="form-group {% if form_errors(elem) %}has-error"{% endif %}">
+                                {{ form_widget(elem) }}
+                                {{ form_errors(elem) }}
+                            </div>
                         </td>
                     {% endfor %}
                 </tr>

--- a/src/Resources/views/select_file.html.twig
+++ b/src/Resources/views/select_file.html.twig
@@ -1,7 +1,7 @@
 {% extends batch_entity_import_template('layout') %}
 
 {% block batch_entity_import_content %}
-    {{ form_start(form) }}
+    {{ form_start(form, {'action': path(app.request.attributes.get('_route')) }) }}
     {{ form_rest(form) }}
     <button type="submit" id="btn-submit" class="btn btn-default">{{ 'form.button.import'|trans({}, 'BatchEntityImportBundle') }}</button>
     {{ form_end(form) }}


### PR DESCRIPTION
- submit the records manually after upload to show the edit page with the form errors if exist
- return to edit page if the data is not valid (instead of returning to upload the file again)
- add config to toggle `override` entity (default true as before)
- remove `PropertyExistenceChecker` and use `property_exist` instead (sometimes we have entity constructor with input params)
- Fix translated fields shown as unknownfields in the edit view
- add action to the form (it's not submitted on my end without action)
- update edit template to have colourful error message and `min-width: 150px` 